### PR TITLE
Added wallet params, fixed win and absolute paths

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,8 @@ import (
 
 var cfgFile string
 var walletFile string
+var walletClientID string
+var walletClientKey string
 var cDir string
 var bVerbose bool
 
@@ -38,6 +40,8 @@ func init() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is config.yaml)")
 	rootCmd.PersistentFlags().StringVar(&walletFile, "wallet", "", "wallet file (default is wallet.json)")
+	rootCmd.PersistentFlags().StringVar(&walletClientID, "wallet_client_id", "", "wallet client_id")
+	rootCmd.PersistentFlags().StringVar(&walletClientKey, "wallet_client_key", "", "wallet client_key")
 	rootCmd.PersistentFlags().StringVar(&cDir, "configDir", "", "configuration directory (default is $HOME/.zcn)")
 	rootCmd.PersistentFlags().BoolVar(&bVerbose, "verbose", false, "prints sdk log in stderr (default false)")
 	initConfig()
@@ -62,7 +66,7 @@ func getConfigDir() string {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	configDir = home + "/.zcn"
+ 	configDir = home + string(os.PathSeparator)+ ".zcn" 
 	return configDir
 }
 
@@ -92,12 +96,7 @@ func initConfig() {
 	//chainID := nodeConfig.GetString("chain_id")
 
 	//TODO: move the private key storage to the keychain or secure storage
-	var walletFilePath string
-	if &walletFile != nil && len(walletFile) > 0 {
-		walletFilePath = configDir + "/" + walletFile
-	} else {
-		walletFilePath = configDir + "/wallet.json"
-	}
+
 	//set the log file
 	zcncore.SetLogFile("cmdlog.log", bVerbose)
 	err := zcncore.InitZCNSDK(blockWorker, signScheme,
@@ -111,6 +110,27 @@ func initConfig() {
 
 	// is freshly created wallet?
 	var fresh bool
+	wallet := &zcncrypto.Wallet{}
+if (&walletClientID != nil) && (len(walletClientID) > 0) && (&walletClientKey != nil) && (len(walletClientKey) > 0) {
+		wallet.ClientID = walletClientID
+		wallet.ClientKey = walletClientKey
+	var clientBytes []byte
+
+	  clientBytes, err = json.Marshal(wallet)
+	  clientConfig = string(clientBytes)
+	  if err != nil {
+		fmt.Println("Invalid wallet data passed:" + walletClientID + " " + walletClientKey)
+		os.Exit(1)
+	}
+	clientWallet = wallet
+	fresh = false		
+} else {
+	var walletFilePath string
+	if &walletFile != nil && len(walletFile) > 0 {
+		walletFilePath = configDir + string(os.PathSeparator) + walletFile
+	} else {
+		walletFilePath = configDir + string(os.PathSeparator) + "wallet.json"
+	}
 
 	if _, err := os.Stat(walletFilePath); os.IsNotExist(err) {
 		fmt.Println("No wallet in path ", walletFilePath, "found. Creating wallet...")
@@ -151,12 +171,12 @@ func initConfig() {
 		clientConfig = string(clientBytes)
 	}
 
-	wallet := &zcncrypto.Wallet{}
 	err = json.Unmarshal([]byte(clientConfig), wallet)
 	clientWallet = wallet
 	if err != nil {
 		ExitWithError("Invalid wallet at path:" + walletFilePath)
 	}
+}
 	wg := &sync.WaitGroup{}
 	err = zcncore.SetWalletInfo(clientConfig, false)
 	if err == nil {


### PR DESCRIPTION
--wallet_client_id and --wallet_client_key can be passed instead of --wallet
Absolute paths to wallets now supported
Windows os specific path delimiter now supported