### PR TITLE
Change pool_id flag from required to optional for mn-pool-info command

### DIFF
--- a/cmd/minersc.go
+++ b/cmd/minersc.go
@@ -376,10 +376,6 @@ var minerscPoolInfo = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		if !flags.Changed("pool_id") {
-			log.Fatal("missing pool_id flag")
-		}
-
 		if poolID, err = flags.GetString("pool_id"); err != nil {
 			log.Fatal(err)
 		}
@@ -581,7 +577,6 @@ func init() {
 	minerscPoolInfo.PersistentFlags().String("id", "", "miner/sharder ID to get info for")
 	minerscPoolInfo.MarkFlagRequired("id")
 	minerscPoolInfo.PersistentFlags().String("pool_id", "", "pool ID to get info for")
-	minerscPoolInfo.MarkFlagRequired("pool_id")
 
 	minerscLock.PersistentFlags().String("id", "", "miner/sharder ID to lock stake for")
 	minerscLock.MarkFlagRequired("id")


### PR DESCRIPTION
This is to return an array of node pools in case a pool_id is not provided.

Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/zwalletcli/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

Associated PRs (Link as appropriate):
- 0chain: https://github.com/0chain/0chain/pull/1502
