### PR TITLE
make id flag mandatory for bridge-auth-config command'

### DIFF
--- a/cmd/bridge-auth-config.go
+++ b/cmd/bridge-auth-config.go
@@ -1,10 +1,11 @@
 package cmd
 
 import (
+	"log"
+
 	"github.com/0chain/gosdk/zcnbridge"
 	"github.com/0chain/zwalletcli/util"
 	"github.com/spf13/cobra"
-	"log"
 )
 
 var getAuthorizerConfigCmd = &cobra.Command{
@@ -23,6 +24,8 @@ var getAuthorizerConfigCmd = &cobra.Command{
 			if ID, err = flags.GetString("id"); err != nil {
 				log.Fatalf("error in 'id' flag: %v", err)
 			}
+		} else {
+			ExitWithError("Error: id flag is missing")
 		}
 
 		var (


### PR DESCRIPTION
A brief description of the changes in this PR:

fixes: https://github.com/0chain/zwalletcli/issues/167

Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/zwalletcli/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- 0chain:
- Other: ...
