### PR TITLE
Add URL argument to bridge-auth-config-update command

### DIFF
--- a/cmd/bridge-auth-config-update.go
+++ b/cmd/bridge-auth-config-update.go
@@ -20,6 +20,7 @@ var updateAuthorizerConfigCmd = &cobra.Command{
 		const (
 			IDFlag  = "id"
 			FeeFlag = "fee"
+			URLFlag = "url"
 		)
 
 		var (
@@ -27,6 +28,7 @@ var updateAuthorizerConfigCmd = &cobra.Command{
 			ID         string
 			Fee        string
 			FeeBalance int64
+			URL        string
 			err        error
 		)
 
@@ -47,8 +49,15 @@ var updateAuthorizerConfigCmd = &cobra.Command{
 			log.Fatalf("error in '%s' flag: %v", FeeFlag, err)
 		}
 
+		if flags.Changed(URLFlag) {
+			if URL, err = flags.GetString(URLFlag); err != nil {
+				log.Fatalf("error in '%s' flag: %v", FeeFlag, err)
+			}
+		}
+
 		node := &zcncore.AuthorizerNode{
-			ID: ID,
+			ID:  ID,
+			URL: URL,
 			Config: &zcncore.AuthorizerConfig{
 				Fee: common.Balance(FeeBalance),
 			},

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/0chain/zwalletcli
 
 require (
-	github.com/0chain/gosdk v1.8.9-0.20220920134710-69c5c99f445a
+	github.com/0chain/gosdk v1.8.9-0.20220928142038-4b3007cb65db
 	github.com/icza/bitio v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -38,10 +38,10 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/0chain/errors v1.0.3 h1:QQZPFxTfnMcRdt32DXbzRQIfGWmBsKoEdszKQDb0rRM=
 github.com/0chain/errors v1.0.3/go.mod h1:xymD6nVgrbgttWwkpSCfLLEJbFO6iHGQwk/yeSuYkIc=
-github.com/0chain/gosdk v1.8.9-0.20220917032231-58dcb0e11d71 h1:KiEQL9DOWchD8u3wUaceJ2b204+Qz1F5f8uIvvPfEc4=
-github.com/0chain/gosdk v1.8.9-0.20220917032231-58dcb0e11d71/go.mod h1:pz+GbjQaMehirDgcUnFBUl0i9RxU79bdaKlqp5FWw70=
 github.com/0chain/gosdk v1.8.9-0.20220920134710-69c5c99f445a h1:Hie6PBgwHBXgcxDU6d1/dvBk7hVN22EjV0a5MGyhX3s=
 github.com/0chain/gosdk v1.8.9-0.20220920134710-69c5c99f445a/go.mod h1:pz+GbjQaMehirDgcUnFBUl0i9RxU79bdaKlqp5FWw70=
+github.com/0chain/gosdk v1.8.9-0.20220928142038-4b3007cb65db h1:Io5IH4O7rZ+Az4BB0Dk2sHXL6P93Uv6HVJtAj4VJK6Q=
+github.com/0chain/gosdk v1.8.9-0.20220928142038-4b3007cb65db/go.mod h1:74ICmmW3mprJWhCPemYIJrw/jNO8pza2HHk5aw+EzN0=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=


### PR DESCRIPTION
A brief description of the changes in this PR:
PR adds URL argument to `bridge-auth-config-update`, which is further passed to `update-authorizer-config` txn type in 0Chain.
Reference Issue: https://github.com/0chain/0chain/issues/1625
Fixes: #173 

Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/zwalletcli/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

Associated PRs (Link as appropriate):
- blobber:
- gosdk: https://github.com/0chain/gosdk/pull/563
- system_test:
- zboxcli:
- 0chain: https://github.com/0chain/0chain/pull/1633
- Other: ...
