### PR TITLE
Use staging gosdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/0chain/zwalletcli
 
 require (
-	github.com/0chain/gosdk v1.8.16-0.20230413113753-137b2bde3136
+	github.com/0chain/gosdk v1.8.16-0.20230417054527-72c52885a20c
 	github.com/ethereum/go-ethereum v1.10.26
 	github.com/icza/bitio v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -40,12 +40,8 @@ github.com/0chain/common v0.0.6-0.20230127095721-8df4d1d72565 h1:z+DtCR8mBsjPnEs
 github.com/0chain/common v0.0.6-0.20230127095721-8df4d1d72565/go.mod h1:UyDC8Qyl5z9lGkCnf9RHJPMektnFX8XtCJZHXCCVj8E=
 github.com/0chain/errors v1.0.3 h1:QQZPFxTfnMcRdt32DXbzRQIfGWmBsKoEdszKQDb0rRM=
 github.com/0chain/errors v1.0.3/go.mod h1:xymD6nVgrbgttWwkpSCfLLEJbFO6iHGQwk/yeSuYkIc=
-github.com/0chain/gosdk v1.8.16-0.20230404034451-5080d6c959e2 h1:zt+HltPrEdAj+OL5Izf6MlqIjK9ix+kgI1fwHzn4dEg=
-github.com/0chain/gosdk v1.8.16-0.20230404034451-5080d6c959e2/go.mod h1:Toq7tLWOhJ/HrwMO1pfM67wsulo+jw82z6y6jgpsmeA=
-github.com/0chain/gosdk v1.8.16-0.20230412230333-3913034418d9 h1:Q6i/PlI2Iq3ScTp0Q3VJ1l+g/Ml/p0zYoiMSBeSWftc=
-github.com/0chain/gosdk v1.8.16-0.20230412230333-3913034418d9/go.mod h1:Toq7tLWOhJ/HrwMO1pfM67wsulo+jw82z6y6jgpsmeA=
-github.com/0chain/gosdk v1.8.16-0.20230413113753-137b2bde3136 h1:KipK2YCfuLeXB8YRTL1uSWrQwlj1h/B4/iqv/NFs01Q=
-github.com/0chain/gosdk v1.8.16-0.20230413113753-137b2bde3136/go.mod h1:Toq7tLWOhJ/HrwMO1pfM67wsulo+jw82z6y6jgpsmeA=
+github.com/0chain/gosdk v1.8.16-0.20230417054527-72c52885a20c h1:+tkwmdxaOjOXBugOZLOs3BMMMCINzL6i+u/DVIf1+N4=
+github.com/0chain/gosdk v1.8.16-0.20230417054527-72c52885a20c/go.mod h1:Toq7tLWOhJ/HrwMO1pfM67wsulo+jw82z6y6jgpsmeA=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Luzifer/go-openssl/v3 v3.1.0 h1:QqKqo6kYXGGUsvtUoCpRZm8lHw+jDfhbzr36gVj+/gw=


### PR DESCRIPTION
A brief description of the changes in this PR:
- Estimate fee log is not removed in the gosdk that staging zwallet CLI is using, this PR fixes it

Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/zwalletcli/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- 0chain:
- Other: ...
