### PR TITLE
Upgrade 0Chain GoSDK to v1.8.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/0chain/zwalletcli
 
 require (
-	github.com/0chain/gosdk v1.8.16-0.20230427161011-6fb50cdcb352
+	github.com/0chain/gosdk v1.8.16
 	github.com/ethereum/go-ethereum v1.10.26
 	github.com/icza/bitio v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/0chain/common v0.0.6-0.20230127095721-8df4d1d72565 h1:z+DtCR8mBsjPnEs
 github.com/0chain/common v0.0.6-0.20230127095721-8df4d1d72565/go.mod h1:UyDC8Qyl5z9lGkCnf9RHJPMektnFX8XtCJZHXCCVj8E=
 github.com/0chain/errors v1.0.3 h1:QQZPFxTfnMcRdt32DXbzRQIfGWmBsKoEdszKQDb0rRM=
 github.com/0chain/errors v1.0.3/go.mod h1:xymD6nVgrbgttWwkpSCfLLEJbFO6iHGQwk/yeSuYkIc=
-github.com/0chain/gosdk v1.8.16-0.20230427161011-6fb50cdcb352 h1:2zPXNeHLBInsKXOJAFWrRzUpDwfZD9HRXGiCNFRKHFw=
-github.com/0chain/gosdk v1.8.16-0.20230427161011-6fb50cdcb352/go.mod h1:z4IjdbQz1dhcM6wdKQWjUYmHoQw3k44QNatb+vdKFAA=
+github.com/0chain/gosdk v1.8.16 h1:nhe4jI/7ZRWDVeannyC0wmv0v3rChiI2bi08PCTRIdA=
+github.com/0chain/gosdk v1.8.16/go.mod h1:z4IjdbQz1dhcM6wdKQWjUYmHoQw3k44QNatb+vdKFAA=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Luzifer/go-openssl/v3 v3.1.0 h1:QqKqo6kYXGGUsvtUoCpRZm8lHw+jDfhbzr36gVj+/gw=


### PR DESCRIPTION
0Chain GoSDK `v1.8.16` is released.
see full changelog on https://github.com/0chain/gosdk/releases/tag/v1.8.16