### PR TITLE
Fix wrong token unit checking

### DIFF
--- a/cmd/bridge-burn-eth.go
+++ b/cmd/bridge-burn-eth.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/0chain/common/core/currency"
-	"github.com/ethereum/go-ethereum/core/types"
 	"time"
+
+	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/0chain/gosdk/zcnbridge"
 )
@@ -31,10 +31,7 @@ func commandBurnEth(b *zcnbridge.BridgeClient, args ...*Arg) {
 		ExitWithError(err, "failed to retrieve current token balance")
 	}
 
-	tokenBalanceZCN, err := currency.Coin(tokenBalance.Int64()).ToZCN()
-	if err != nil {
-		ExitWithError(err, "failed to convert current token balance to ZCN")
-	}
+	tokenBalanceZCN := tokenBalance.Int64()
 
 	var (
 		transaction *types.Transaction
@@ -42,7 +39,7 @@ func commandBurnEth(b *zcnbridge.BridgeClient, args ...*Arg) {
 		status      int
 	)
 
-	if tokenBalanceZCN < float64(amount) {
+	if tokenBalanceZCN < int64(amount) {
 		transaction, err = b.Swap(context.Background(), amount, time.Now().Add(time.Minute*3))
 		if err != nil {
 			ExitWithError(err, "failed to execute Swap")


### PR DESCRIPTION
A brief description of the changes in this PR:
In `bridge-burn-eth`, we check if the current token balance amount is greater than the amount to burn. But it used wrong token unit, the token balance was in ZCN, but the `amount` is in SAS. 


Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/zwalletcli/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- 0chain:
- Other: ...
