### PR TITLE
Add option to bridge-mint-zcn to mint specific burn txn

### DIFF
--- a/cmd/bridge-mint-zcn.go
+++ b/cmd/bridge-mint-zcn.go
@@ -18,10 +18,18 @@ func init() {
 			"mint zcn tokens using the hash of Ethereum burn transaction",
 			"mint zcn tokens after burning WZCN tokens in Ethereum chain",
 			commandMintZCN,
+			&Option{
+				name:     "burn-txn-hash",
+				typename: "string",
+				value:    "",
+				usage:    "mint the ZCN tokens for the given Ethereum burn transaction hash",
+			},
 		))
 }
 
 func commandMintZCN(b *zcnbridge.BridgeClient, args ...*Arg) {
+	burnHash := getString(args, "burn-txn-hash")
+
 	var mintNonce int64
 	cb := wallet.NewZCNStatus(&mintNonce)
 
@@ -48,6 +56,13 @@ func commandMintZCN(b *zcnbridge.BridgeClient, args ...*Arg) {
 	fmt.Printf("Found %d not processed WZCN burn transactions\n", len(burnTickets))
 
 	for _, burnTicket := range burnTickets {
+
+		if len(burnHash) > 0 {
+			if burnHash != burnTicket.TransactionHash {
+				continue
+			}
+		}
+
 		fmt.Printf("Query ticket for Ethereum transaction hash: %s\n", burnTicket.TransactionHash)
 
 		payload, err := b.QueryZChainMintPayload(burnTicket.TransactionHash)


### PR DESCRIPTION
A brief description of the changes in this PR:

Added option `burn-txn-hash` to `bridge-mint-zcn` to mint specific transaction. If not provided, all burns will be minted.

Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/zwalletcli/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- 0chain:
- Other: ...
