### PR TITLE
remove InitSignatureScheme call

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -142,9 +142,6 @@ func loadConfigs() {
 	CfmChainLength = cfgConfig.GetInt("confirmation_chain_length")
 	signatureScheme = cfgConfig.GetString("signature_scheme")
 
-	//initialize signature scheme for createmswallet and recoverwallet
-	zcncore.InitSignatureScheme(signatureScheme)
-
 	// ~/.zcn/network.yaml
 	cfgNetwork.AddConfigPath(configDir)
 	if len(networkFile) > 0 {


### PR DESCRIPTION
A brief description of the changes in this PR:

To remove `InitSignatureScheme` call.  This function will be deprecated in `gosdk`. This function call happens before `gosdk` initialization in `root.go` . By current implementation, `gosdk` can't be initialized more than once.

Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/zwalletcli/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

Associated PRs (Link as appropriate):
- blobber:
- gosdk: https://github.com/0chain/gosdk/pull/1384
- system_test:
- zboxcli:
- 0chain:
- Other: ...
