### PR TITLE
Upgrade 0Chain GoSDK to sprint-1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.5
 
 require (
-	github.com/0chain/gosdk v1.18.0-RC9
+	github.com/0chain/gosdk v1.18.0-RC9.0.20241113140940-8cf79f5c8b55
 	github.com/ethereum/go-ethereum v1.13.2
 	github.com/icza/bitio v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
@@ -16,7 +16,7 @@ require (
 )
 
 require (
-	github.com/0chain/common v1.18.2 // indirect
+	github.com/0chain/common v1.18.3 // indirect
 	github.com/0chain/errors v1.0.3 // indirect
 	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/Luzifer/go-openssl/v3 v3.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,12 +36,12 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/0chain/common v1.18.2 h1:VGWfd3Xqio9xbmebPFnUbuk5QN0pK0xzvifaUggJF5g=
-github.com/0chain/common v1.18.2/go.mod h1:Lapu2Tj7z5Sm4r+X141e7vsz4NDODTEypeElYAP3iSw=
+github.com/0chain/common v1.18.3 h1:42dYOv2KyMTSanuS67iDtfv+ErbSRqR8NJ3MG72MwaI=
+github.com/0chain/common v1.18.3/go.mod h1:Lapu2Tj7z5Sm4r+X141e7vsz4NDODTEypeElYAP3iSw=
 github.com/0chain/errors v1.0.3 h1:QQZPFxTfnMcRdt32DXbzRQIfGWmBsKoEdszKQDb0rRM=
 github.com/0chain/errors v1.0.3/go.mod h1:xymD6nVgrbgttWwkpSCfLLEJbFO6iHGQwk/yeSuYkIc=
-github.com/0chain/gosdk v1.18.0-RC9 h1:vGkdZnt7uS+1OmgS1Qv/6wFPlZqUoJvqWuenf0tMffs=
-github.com/0chain/gosdk v1.18.0-RC9/go.mod h1:q/zFTOMHU2hFGjFzIxCOZLonsmrSzYVP3ExCHHOmL6w=
+github.com/0chain/gosdk v1.18.0-RC9.0.20241113140940-8cf79f5c8b55 h1:Pei2bn8qr876P0du8zCO/AGtsuD0xSeB56SHsnFu3JQ=
+github.com/0chain/gosdk v1.18.0-RC9.0.20241113140940-8cf79f5c8b55/go.mod h1:8unFy9Dx2YyPKMYPDGR3MFhUEymbAfQcRDm9bobVLGw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=


### PR DESCRIPTION
0Chain GoSDK `sprint-1.18` is released.
see full changelog on https://github.com/0chain/gosdk/releases/tag/sprint-1.18